### PR TITLE
Allow config in requests

### DIFF
--- a/backend/chat/chat.py
+++ b/backend/chat/chat.py
@@ -16,13 +16,14 @@ class ChatAgentWithMemory:
     def __init__(
         self,
         report: str,
-        config_path,
-        headers,
-        vector_store = None
+        config_path=None,
+        headers=None,
+        vector_store=None,
+        config=None
     ):
         self.report = report
         self.headers = headers
-        self.config = Config(config_path)
+        self.config = Config(config_path, config)
         self.vector_store = vector_store
         self.graph = self.create_agent()
 

--- a/backend/report_type/basic_report/basic_report.py
+++ b/backend/report_type/basic_report/basic_report.py
@@ -14,9 +14,10 @@ class BasicReport:
         source_urls,
         document_urls,
         tone: Any,
-        config_path: str,
+        config_path: str | None,
         websocket: WebSocket,
-        headers=None
+        headers=None,
+        config=None
     ):
         self.query = query
         self.query_domains = query_domains
@@ -26,6 +27,7 @@ class BasicReport:
         self.document_urls = document_urls
         self.tone = tone
         self.config_path = config_path
+        self.config = config
         self.websocket = websocket
         self.headers = headers or {}
 
@@ -39,6 +41,7 @@ class BasicReport:
             document_urls=self.document_urls,
             tone=self.tone,
             config_path=self.config_path,
+            config=self.config,
             websocket=self.websocket,
             headers=self.headers
         )

--- a/backend/report_type/detailed_report/detailed_report.py
+++ b/backend/report_type/detailed_report/detailed_report.py
@@ -20,6 +20,7 @@ class DetailedReport:
         subtopics: List[Dict] = [],
         headers: Optional[Dict] = None,
         complement_source_urls: bool = False,
+        config=None,
     ):
         self.query = query
         self.report_type = report_type
@@ -28,6 +29,7 @@ class DetailedReport:
         self.document_urls = document_urls
         self.query_domains = query_domains
         self.config_path = config_path
+        self.config = config
         self.tone = tone
         self.websocket = websocket
         self.subtopics = subtopics
@@ -42,6 +44,7 @@ class DetailedReport:
             source_urls=self.source_urls,
             document_urls=self.document_urls,
             config_path=self.config_path,
+            config=self.config,
             tone=self.tone,
             websocket=self.websocket,
             headers=self.headers,
@@ -107,7 +110,9 @@ class DetailedReport:
             role=self.gpt_researcher.role,
             tone=self.tone,
             complement_source_urls=self.complement_source_urls,
-            source_urls=self.source_urls
+            source_urls=self.source_urls,
+            config_path=self.config_path,
+            config=self.config
         )
 
         subtopic_assistant.context = list(set(self.global_context))

--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -50,6 +50,7 @@ class ResearchRequest(BaseModel):
     repo_name: str
     branch_name: str
     generate_in_background: bool = True
+    config: dict | None = None
 
 
 class ConfigRequest(BaseModel):
@@ -133,6 +134,7 @@ async def write_report(research_request: ResearchRequest, research_id: str = Non
         headers=research_request.headers,
         query_domains=[],
         config_path="",
+        config_dict=research_request.config,
         return_researcher=True
     )
 

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -6,6 +6,7 @@ import time
 import shutil
 import traceback
 from typing import Awaitable, Dict, List, Any
+from gpt_researcher.config.variables.base import BaseConfig
 from fastapi.responses import JSONResponse, FileResponse
 from gpt_researcher.document.document import DocumentLoader
 from gpt_researcher import GPTResearcher
@@ -129,6 +130,7 @@ async def handle_start_command(websocket, data: str, manager):
         headers,
         report_source,
         query_domains,
+        config,
     ) = extract_command_data(json_data)
 
     if not task or not report_type:
@@ -157,6 +159,7 @@ async def handle_start_command(websocket, data: str, manager):
         websocket,
         headers,
         query_domains,
+        config,
     )
     report = str(report)
     file_paths = await generate_report_files(report, sanitized_filename)
@@ -314,4 +317,15 @@ def extract_command_data(json_data: Dict) -> tuple:
         json_data.get("headers", {}),
         json_data.get("report_source"),
         json_data.get("query_domains", []),
+        extract_config(json_data),
     )
+
+
+def extract_config(json_data: Dict) -> Dict[str, Any]:
+    config = json_data.get("config", {}).copy()
+    for key in BaseConfig.__annotations__.keys():
+        if key in json_data:
+            config[key] = json_data[key]
+        elif key.lower() in json_data:
+            config[key] = json_data[key.lower()]
+    return config

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -43,6 +43,7 @@ class GPTResearcher:
         vector_store=None,
         vector_store_filter=None,
         config_path=None,
+        config: dict | None = None,
         websocket=None,
         agent=None,
         role=None,
@@ -58,7 +59,7 @@ class GPTResearcher:
     ):
         self.query = query
         self.report_type = report_type
-        self.cfg = Config(config_path)
+        self.cfg = Config(config_path, config)
         self.cfg.set_verbose(verbose)
         self.llm = GenericLLMProvider(self.cfg)
         self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', None)

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -12,13 +12,27 @@ class Config:
 
     CONFIG_DIR = os.path.join(os.path.dirname(__file__), "variables")
 
-    def __init__(self, config_path: str | None = None):
-        """Initialize the config class."""
+    def __init__(self, config_path: str | None = None, config_dict: Dict[str, Any] | None = None):
+        """Initialize the config class.
+
+        Parameters
+        ----------
+        config_path: str | None
+            Optional path to a JSON configuration file. If ``None`` the
+            default configuration is used.
+        config_dict: Dict[str, Any] | None
+            Dictionary of configuration values that override the defaults.
+        """
         self.config_path = config_path
         self.llm_kwargs: Dict[str, Any] = {}
         self.embedding_kwargs: Dict[str, Any] = {}
 
         config_to_use = self.load_config(config_path)
+        if config_dict:
+            normalized = {k.upper(): v for k, v in config_dict.items()}
+            for key in DEFAULT_CONFIG:
+                if key in normalized and normalized[key] is not None:
+                    config_to_use[key] = normalized[key]
         self._set_attributes(config_to_use)
         self._set_embedding_attributes()
         self._set_llm_attributes()


### PR DESCRIPTION
## Summary
- add `config_dict` support to `Config`
- pass config overrides through `GPTResearcher` and report classes
- extend websocket start command to accept config parameters
- support config in REST endpoints

## Testing
- `pytest -q` *(fails: PytestUnknownMarkWarning / errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6847d58e8cb08322a07c981d169bb99b