### PR TITLE
Add SSE streaming endpoint

### DIFF
--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -117,10 +117,12 @@ async def run_agent(
     config_path="",
     config_dict=None,
     return_researcher=False,
+    logs_handler: CustomLogsHandler | None = None,
 ):
-    """Run the agent."""    
-    # Create logs handler for this research task
-    logs_handler = CustomLogsHandler(websocket, task)
+    """Run the agent."""
+    # Create logs handler for this research task if not provided
+    if logs_handler is None:
+        logs_handler = CustomLogsHandler(websocket=websocket, task=task)
 
     # Initialize researcher based on report type
     if report_type == "multi_agents":


### PR DESCRIPTION
## Summary
- support SSE streaming by adding `/sse` endpoint
- allow `CustomLogsHandler` to forward messages to SSE queue
- allow optional `logs_handler` param in `run_agent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'arxiv')*

------
https://chatgpt.com/codex/tasks/task_b_68496fe43e788322b1152f711af84d53